### PR TITLE
Add CRaCCheckpointTo and CRaCRestoreFrom

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'release-*'
+    branches:
+      - '*'
 
 jobs:
   build:
@@ -48,16 +50,31 @@ jobs:
         sudo chmod u+s jdk14-crac/lib/criu
         tar -zcf jdk14-crac.tar.gz jdk14-crac
 
+    - uses: actions/upload-artifact@v2
+      with:
+        name: jdk
+        path: jdk14-crac.tar.gz
+
+    - name: Compress docs
+      run: tar -zcf docs.tar.gz docs
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: docs
+        path: docs.tar.gz
+
     - name: Delete old release
       run: |
         id=$(curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/org-crac/jdk/releases/tags/release-${{ steps.compute.outputs.name }} | jq '.id')
         curl -X DELETE -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/org-crac/jdk/releases/$id || true
+      if: startsWith(github.ref, 'refs/tags/release-')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
+      if: startsWith(github.ref, 'refs/tags/release-')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -66,9 +83,10 @@ jobs:
         draft: false
         prerelease: false
 
-    - name: Upload JDK
+    - name: Upload JDK release
       id: upload-jdk
       uses: actions/upload-release-asset@v1
+      if: startsWith(github.ref, 'refs/tags/release-')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -79,6 +97,7 @@ jobs:
 
     - name: Checkout gh-pages
       uses: actions/checkout@v2
+      if: startsWith(github.ref, 'refs/tags/release-')
       with:
         ref: 'gh-pages'
         path: 'gh-pages'
@@ -91,3 +110,4 @@ jobs:
         git -C gh-pages add .
         git -C gh-pages commit -m 'Update ${{ steps.compute.outputs.name }}'
         git -C gh-pages push origin gh-pages
+      if: startsWith(github.ref, 'refs/tags/release-')

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -31,7 +31,10 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - run: bash ./configure --disable-warnings-as-errors --with-native-debug-symbols=none
+    - run: bash ./configure
+        --disable-warnings-as-errors
+        --with-version-pre=crac
+        --with-native-debug-symbols=none
       shell: docker exec build bash -e {0}
 
     - run: |

--- a/make/launcher/Launcher-java.base.gmk
+++ b/make/launcher/Launcher-java.base.gmk
@@ -103,9 +103,9 @@ endif
 
 ifeq ($(OPENJDK_TARGET_OS), linux)
   $(eval $(call SetupJdkExecutable, BUILD_RESTORE_SCRIPT, \
-      NAME := restore-script, \
-      SRC := $(TOPDIR)/src/$(MODULE)/unix/native/restore-script, \
-      INCLUDE_FILES := restore-script.c, \
+      NAME := action-script, \
+      SRC := $(TOPDIR)/src/$(MODULE)/unix/native/action-script, \
+      INCLUDE_FILES := action-script.c, \
       OPTIMIZATION := HIGH, \
       CFLAGS := $(CFLAGS_JDKEXE), \
       LDFLAGS := $(LDFLAGS_JDKEXE), \

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -6958,7 +6958,7 @@ int os::Linux::restore() {
       "--shell-job",
       "--action-script", restore_script,
       "-D", crdir,
-      "-v4", "-o", "/tmp/restore4.log",
+      "-v1",
       "--exec-cmd", "--", wait,
       (char*)NULL);
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -303,6 +303,8 @@ bool os::Linux::_supports_fast_thread_cpu_time = false;
 const char * os::Linux::_glibc_version = NULL;
 const char * os::Linux::_libpthread_version = NULL;
 
+static const char* _criu = NULL;
+
 static jlong initial_time_count=0;
 
 static int clock_tics_per_sec = 100;
@@ -6328,7 +6330,7 @@ static void trace_cr(const char* msg, ...) {
 }
 
 void os::Linux::vm_create_start() {
-  if (!Arguments::can_checkpoint()) {
+  if (!CRaCCheckpointTo) {
     return;
   }
   _vm_inited_fds.initialize();
@@ -6513,21 +6515,57 @@ static void mark_persistent(FdsInfo *fds) {
   _persistent_resources = NULL;
 }
 
+static void cr_util_path(char* path, int len) {
+  os::jvm_path(path, len);
+  // path is ".../lib/server/libjvm.so"
+  for (int i = 0; i < 2; ++i) {
+    char *after_elem = strrchr(path, '/');
+    *after_elem = '\0';
+  }
+}
+
+static const char* compute_criu(const char *util_path) {
+  if (_criu) {
+    return _criu;
+  }
+
+#define SUF "criu"
+  const size_t criulen = strlen(util_path) + 1 + sizeof(SUF);
+  char *criu = NEW_C_HEAP_ARRAY(char, criulen, mtInternal);
+  assert(criu != NULL, "JVM should fail");
+  int r = jio_snprintf(criu, criulen, "%s/" SUF, util_path);
+#undef SUF
+  assert(r < (int)criulen, "len miscalc");
+
+  struct stat dummy;
+  if (0 == stat(criu, &dummy)) {
+    _criu = criu;
+  } else {
+    FREE_C_HEAP_ARRAY(char, criu);
+    warning("Could not find %s: %s", criu, strerror(errno));
+    // use system one
+    _criu = "criu";
+  }
+  return _criu;
+}
+
 static int call_criu() {
-  char cmd[1024];
+  char util_path[JVM_MAXPATHLEN];
+  cr_util_path(util_path, sizeof(util_path));
+
+  const char* criu = compute_criu(util_path);
 
   pid_t jvm = getpid();
 
-  const char* crdir = Arguments::crdir();
-  const char* criu = Arguments::criu();
-
+  char cmd[3 * JVM_MAXPATHLEN];
   if ((int)sizeof(cmd) <= snprintf(cmd, sizeof(cmd),
         "%s dump"
         " -t %d"
         " -D %s"
+        " --action-script %s/action-script"
         " --shell-job"
         " -v4 -o dump4.log", // -D without -W makes criu cd to image dir for logs
-        criu, jvm, crdir)) {
+        criu, jvm, CRaCCheckpointTo, util_path)) {
     trace_cr("can't fit CRIU cmd");
     return -1;
   }
@@ -6787,7 +6825,7 @@ void VM_Crac::doit() {
     return;
   }
 
-  if (!PerfMemory::checkpoint()) {
+  if (!PerfMemory::checkpoint(CRaCCheckpointTo)) {
     return;
   }
 
@@ -6803,7 +6841,7 @@ void VM_Crac::doit() {
 }
 
 void os::Linux::register_persistent_fd(int fd, int st_dev, int st_ino) {
-  if (!Arguments::can_checkpoint()) {
+  if (!CRaCCheckpointTo) {
     return;
   }
   if (!_persistent_resources) {
@@ -6831,7 +6869,7 @@ void os::Linux::register_persistent_fd(int fd, int st_dev, int st_ino) {
 }
 
 void os::Linux::deregister_persistent_fd(int fd, int st_dev, int st_ino) {
-  if (!Arguments::can_checkpoint()) {
+  if (!CRaCCheckpointTo) {
     return;
   }
   if (!_persistent_resources) {
@@ -6847,6 +6885,28 @@ void os::Linux::deregister_persistent_fd(int fd, int st_dev, int st_ino) {
   if (i < _persistent_resources->length()) {
     _persistent_resources->remove_at(i);
   }
+}
+
+bool os::Linux::prepare_checkpoint() {
+  struct stat st;
+
+  if (0 == stat(CRaCCheckpointTo, &st)) {
+    if ((st.st_mode & S_IFMT) != S_IFDIR) {
+      warning("%s: not a directory", CRaCCheckpointTo);
+      return false;
+    }
+  } else {
+    if (-1 == mkdir(CRaCCheckpointTo, 0700)) {
+      warning("cannot create %s: %s", CRaCCheckpointTo, strerror(errno));
+      return false;
+    }
+    if (-1 == rmdir(CRaCCheckpointTo)) {
+      warning("cannot cleanup after check: %s", strerror(errno));
+      // not fatal
+    }
+  }
+
+  return true;
 }
 
 static Handle ret_cr(int ret, Handle codes, Handle msgs, TRAPS) {
@@ -6867,7 +6927,12 @@ static Handle ret_cr(int ret, TRAPS) {
 /** Checkpoint main entry.
  */
 Handle os::Linux::checkpoint(TRAPS) {
-  if (!Arguments::can_checkpoint()) {
+  if (!CRaCCheckpointTo) {
+    return ret_cr(JVM_CHECKPOINT_NONE, THREAD);
+  }
+
+  if (-1 == mkdir(CRaCCheckpointTo, 0700) && errno != EEXIST) {
+    warning("cannot create %s: %s", CRaCCheckpointTo, strerror(errno));
     return ret_cr(JVM_CHECKPOINT_NONE, THREAD);
   }
 
@@ -6915,55 +6980,87 @@ static char* add_arg(char** begin_p, char* end, const char *fmt, ...) {
   return begin;
 }
 
-int os::Linux::restore() {
-  char path[JVM_MAXPATHLEN];
-  os::jvm_path(path, sizeof(path));
+void os::Linux::restore() {
+  struct stat st;
 
-  // path is ".../lib/server/libjvm.so"
-  for (int i = 0; i < 2; ++i) {
-    char *after_elem = strrchr(path, '/');
-    if (after_elem == NULL) {
-      trace_cr("can't get base dir (%d)", i);
-      return -1;
-    }
-    *after_elem = '\0';
+  char util_path[JVM_MAXPATHLEN];
+  cr_util_path(util_path, sizeof(util_path));
+
+  const char *criu = compute_criu(util_path);
+
+  char tempbuf[4 * JVM_MAXPATHLEN];
+  char* end = tempbuf + sizeof(tempbuf);
+  char* bufp = tempbuf;
+
+  snprintf(bufp, end - bufp, "%s/cppath", CRaCRestoreFrom);
+  int fd_cppath = ::open(bufp, O_RDONLY);
+  if (fd_cppath < 0) {
+    trace_cr("no valid image to restore: %s", CRaCRestoreFrom);
+    return;
   }
+  int cppathlen = read(fd_cppath, bufp, end - bufp);
+  close(fd_cppath);
 
-  char buf[1024];
-  char* end = buf + sizeof(buf);
-  char* bufp = buf;
+  char *cppath = bufp;
+  if (cppathlen < 0) {
+    warning("cannot read image: %s", strerror(errno));
+    return;
+  }
+  if (cppathlen == end - bufp) {
+    warning("invalid image: content too long");
+    return;
+  }
+  bufp[cppathlen] = '\0';
+  bufp += cppathlen + 1;
 
-  char* restore_script = add_arg(&bufp, end, "%s/restore-script", path);
+  char* restore_script = add_arg(&bufp, end, "%s/action-script", util_path);
   if (!restore_script) {
-    trace_cr("can't format restore-script path");
-    return -1;
+    warning("cannot format restore_script path");
+    return;
   }
 
-  char* wait = add_arg(&bufp, end, "%s/wait", path);
+  char* wait = add_arg(&bufp, end, "%s/wait", util_path);
   if (!wait) {
-    trace_cr("can't format restore-script path");
-    return -1;
+    warning("cannot format action-script path");
+    return;
   }
 
-  const char* crdir = Arguments::crdir();
-  const char* criu = Arguments::criu();
+  snprintf(bufp, end - bufp, "%s/perfdata", CRaCRestoreFrom);
+  int fd_perfdata = ::open(bufp, O_RDWR);
+  char* inherit_perfdata = NULL;
+  if (0 < fd_perfdata) {
+    inherit_perfdata = add_arg(&bufp, end, "fd[%d]:%s/perfdata", fd_perfdata,
+        cppath[0] == '/' ? cppath + 1 : cppath);
+  }
 
   if (CRTraceStartupTime) {
     tty->print_cr("STARTUPTIME " JLONG_FORMAT " criu-call", os::javaTimeNanos());
   }
 
-  int ret = execlp(/*file*/criu, /*args follow*/
-      criu, "restore",
-      "-W", ".",
-      "--shell-job",
-      "--action-script", restore_script,
-      "-D", crdir,
-      "-v1",
-      "--exec-cmd", "--", wait,
-      (char*)NULL);
+  const char* args[32];
+  const char** argp = args;
+  *argp++ = criu;
+  *argp++ = "restore";
+  *argp++ = "-W";
+  *argp++ = ".";
+  if (inherit_perfdata) {
+    *argp++ = "--inherit-fd";
+    *argp++ = inherit_perfdata;
+  }
+  *argp++ = "--shell-job";
+  *argp++ = "--action-script";
+  *argp++ = restore_script;
+  *argp++ = "-D";
+  *argp++ = CRaCRestoreFrom;
+  *argp++ = "-v1";
+  *argp++ = "--exec-cmd";
+  *argp++ = "--";
+  *argp++ = wait;
+  *argp++ = NULL;
+  guarantee(argp - args < (int)ARRAY_SIZE(args), "args overflow");
 
-  trace_cr("can't execute \"%s restore ...\" (%s)", criu, strerror(errno));
-  return -1;
+  execvp(criu, (char**)args);
+  warning("cannot execute \"%s restore ...\" (%s)", criu, strerror(errno));
 }
 
 /////////////// Unit tests ///////////////

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -201,8 +201,9 @@ class Linux {
   static jlong fast_thread_cpu_time(clockid_t clockid);
 
   static void vm_create_start();
+  static bool prepare_checkpoint();
   static Handle checkpoint(TRAPS);
-  static int restore();
+  static void restore();
   static void register_persistent_fd(int fd, int st_dev, int st_ino);
   static void deregister_persistent_fd(int fd, int st_dev, int st_ino);
 

--- a/src/hotspot/os/linux/perfMemory_linux.cpp
+++ b/src/hotspot/os/linux/perfMemory_linux.cpp
@@ -30,6 +30,7 @@
 #include "memory/resourceArea.hpp"
 #include "oops/oop.inline.hpp"
 #include "os_linux.inline.hpp"
+#include "perfMemory_linux.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/os.hpp"
 #include "runtime/perfMemory.hpp"
@@ -1349,7 +1350,7 @@ void PerfMemory::detach(char* addr, size_t bytes, TRAPS) {
   unmap_shared(addr, bytes);
 }
 
-bool PerfMemory::checkpoint(const char* checkpoint_path) {
+bool PerfMemoryLinux::checkpoint(const char* checkpoint_path) {
   assert(checkpoint_path, "should be set");
 
   if (!backing_store_file_name) {
@@ -1357,7 +1358,7 @@ bool PerfMemory::checkpoint(const char* checkpoint_path) {
   }
 
   char path[JVM_MAXPATHLEN];
-  int pathlen = snprintf(path, sizeof(path),"%s/perfdata", checkpoint_path);
+  int pathlen = snprintf(path, sizeof(path),"%s/%s", checkpoint_path, perfdata_name());
 
   RESTARTABLE(::open(path, O_RDWR|O_CREAT|O_NOFOLLOW, S_IRUSR|S_IWUSR), checkpoint_fd);
   if (checkpoint_fd < 0) {
@@ -1365,8 +1366,8 @@ bool PerfMemory::checkpoint(const char* checkpoint_path) {
     return false;
   }
 
-  char* p = start();
-  size_t len = capacity();
+  char* p = PerfMemory::start();
+  size_t len = PerfMemory::capacity();
   do {
     int result;
     RESTARTABLE(::write(checkpoint_fd, p, len), result);
@@ -1380,7 +1381,8 @@ bool PerfMemory::checkpoint(const char* checkpoint_path) {
     len -= (size_t)result;
   } while (0 < len);
 
-  void* mmapret = ::mmap(start(), capacity(), PROT_READ|PROT_WRITE, MAP_FIXED|MAP_SHARED, checkpoint_fd, 0);
+  void* mmapret = ::mmap(PerfMemory::start(), PerfMemory::capacity(),
+      PROT_READ|PROT_WRITE, MAP_FIXED|MAP_SHARED, checkpoint_fd, 0);
   if (MAP_FAILED == mmapret) {
     tty->print_cr("cannot mmap checkpoint perfdata file: %s", os::strerror(errno));
     ::close(checkpoint_fd);
@@ -1391,7 +1393,7 @@ bool PerfMemory::checkpoint(const char* checkpoint_path) {
   return true;
 }
 
-bool PerfMemory::checkpoint_fail() {
+bool PerfMemoryLinux::checkpoint_fail() {
   if (checkpoint_fd < 0) {
     return true;
   }
@@ -1403,7 +1405,8 @@ bool PerfMemory::checkpoint_fail() {
     return false;
   }
 
-  void* mmapret = ::mmap(start(), capacity(), PROT_READ|PROT_WRITE, MAP_FIXED|MAP_SHARED, fd, 0);
+  void* mmapret = ::mmap(PerfMemory::start(), PerfMemory::capacity(),
+      PROT_READ|PROT_WRITE, MAP_FIXED|MAP_SHARED, fd, 0);
   if (MAP_FAILED == mmapret) {
     tty->print_cr("cannot mmap old perfdata file: %s", os::strerror(errno));
     ::close(fd);
@@ -1413,7 +1416,7 @@ bool PerfMemory::checkpoint_fail() {
   return true;
 }
 
-bool PerfMemory::restore() {
+bool PerfMemoryLinux::restore() {
   if (checkpoint_fd < 0) {
     return true;
   }
@@ -1430,15 +1433,16 @@ bool PerfMemory::restore() {
   if (fd == OS_ERR) {
     tty->print_cr("cannot open restore perfdata file: %s", os::strerror(errno));
 
-    void* mmapret = ::mmap(start(), capacity(), PROT_READ|PROT_WRITE, MAP_FIXED|MAP_PRIVATE, checkpoint_fd, 0);
+    void* mmapret = ::mmap(PerfMemory::start(), PerfMemory::capacity(),
+        PROT_READ|PROT_WRITE, MAP_FIXED|MAP_PRIVATE, checkpoint_fd, 0);
     if (MAP_FAILED == mmapret) {
       tty->print_cr("cannot remap checkpoint perfdata file: %s", os::strerror(errno));
     }
     return false;
   }
 
-  char* p = start();
-  size_t len = capacity();
+  char* p = PerfMemory::start();
+  size_t len = PerfMemory::capacity();
   do {
     int result;
     RESTARTABLE(::write(fd, p, len), result);
@@ -1451,7 +1455,8 @@ bool PerfMemory::restore() {
     len -= (size_t)result;
   } while (0 < len);
 
-  void* mmapret = ::mmap(start(), capacity(), PROT_READ|PROT_WRITE, MAP_FIXED|MAP_SHARED, fd, 0);
+  void* mmapret = ::mmap(PerfMemory::start(), PerfMemory::capacity(),
+      PROT_READ|PROT_WRITE, MAP_FIXED|MAP_SHARED, fd, 0);
   if (MAP_FAILED == mmapret) {
     tty->print_cr("cannot mmap restore perfdata file: %s", os::strerror(errno));
     ::close(fd);

--- a/src/hotspot/os/linux/perfMemory_linux.cpp
+++ b/src/hotspot/os/linux/perfMemory_linux.cpp
@@ -1349,18 +1349,15 @@ void PerfMemory::detach(char* addr, size_t bytes, TRAPS) {
   unmap_shared(addr, bytes);
 }
 
-bool PerfMemory::checkpoint() {
+bool PerfMemory::checkpoint(const char* checkpoint_path) {
+  assert(checkpoint_path, "should be set");
+
   if (!backing_store_file_name) {
     return true;
   }
 
-  if (!Arguments::crdir()) {
-    tty->print_cr("checkpoint dir is not set");
-    return false;
-  }
-
   char path[JVM_MAXPATHLEN];
-  int pathlen = snprintf(path, sizeof(path),"%s/perfdata", Arguments::crdir());
+  int pathlen = snprintf(path, sizeof(path),"%s/perfdata", checkpoint_path);
 
   RESTARTABLE(::open(path, O_RDWR|O_CREAT|O_NOFOLLOW, S_IRUSR|S_IWUSR), checkpoint_fd);
   if (checkpoint_fd < 0) {

--- a/src/hotspot/os/linux/perfMemory_linux.hpp
+++ b/src/hotspot/os/linux/perfMemory_linux.hpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_LINUX_PERFMEMORY_LINUX_HPP
+#define OS_LINUX_PERFMEMORY_LINUX_HPP
+
+#include "memory/allocation.hpp"
+
+class PerfMemoryLinux : AllStatic {
+
+public:
+  static inline const char* perfdata_name() {
+    return "perfdata";
+  }
+
+  static bool checkpoint(const char* checkpoint_path);
+  static bool checkpoint_fail();
+  static bool restore();
+};
+
+#endif // OS_LINUX_PERFMEMORY_LINUX_HPP
+

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -61,8 +61,6 @@
 #include "jfr/jfr.hpp"
 #endif
 
-#include <libgen.h>
-
 #define DEFAULT_JAVA_LAUNCHER  "generic"
 
 char*  Arguments::_jvm_flags_file               = NULL;
@@ -94,10 +92,6 @@ bool   Arguments::_enable_preview               = false;
 
 char*  Arguments::SharedArchivePath             = NULL;
 char*  Arguments::SharedDynamicArchivePath      = NULL;
-
-Arguments::CRMode Arguments::_crmode = Arguments::CRNone;
-const char* Arguments::_crdir = NULL;
-const char* Arguments::_criu = NULL;
 
 AgentLibraryList Arguments::_libraryList;
 AgentLibraryList Arguments::_agentList;
@@ -288,82 +282,6 @@ bool Arguments::has_jfr_option() {
   return _has_jfr_option;
 }
 #endif
-
-bool Arguments::compute_criu_args(const char* optdir) {
-  const char* fs = os::file_separator();
-  const size_t fsl = strlen(fs);
-
-  char jvm_path[JVM_MAXPATHLEN];
-  os::jvm_path(jvm_path, sizeof(jvm_path));
-  // jdk/lib/server/libjvm.so
-  char *end = strrchr(jvm_path, *fs);
-  if (end != NULL) *end = '\0';
-  // jdk/lib/server
-  end = strrchr(jvm_path, *fs);
-  if (end != NULL) *end = '\0';
-  // jdk/lib
-  const char* variant = end != NULL ? end + 1 : "";
-  const int variant_len = strlen(variant);
-  const int jvm_path_len = strlen(jvm_path);
-
-  struct stat dummy;
-
-  if (optdir[0] == ':') {
-    _crdir = optdir + 1;
-  } else if (optdir[0] == '\0') {
-#define SUF "/cr"
-    const size_t crdirlen = jvm_path_len + fsl + variant_len + fsl + sizeof(SUF);
-    char *crdir = NEW_C_HEAP_ARRAY(char, crdirlen, mtInternal);
-    if (crdir != NULL) {
-      int r = jio_snprintf(crdir, crdirlen, "%s%s%s%s" SUF,
-          jvm_path, fs, variant, fs);
-      assert(r < (int)crdirlen, "len miscalc");
-      _crdir = crdir;
-    }
-#undef SUF
-  } else {
-    return false;
-  }
-
-  if (-1 == stat(_crdir, &dummy)) {
-    char* basebuf = strdup(_crdir);
-    char* base = ::basename(basebuf);
-    char* dirbuf = strdup(_crdir);
-    char* dir = ::dirname(dirbuf);
-
-    int dirfd = open(dir, O_RDONLY | O_DIRECTORY);
-    if (dirfd < 0) {
-      tty->print_cr("can't open CRDIR base %s", dir);
-      return false;
-    }
-    if (mkdirat(dirfd, base, 0700) < 0) {
-      tty->print_cr("can't create %s under dir %s", base, dir);
-      return false;
-    }
-    close(dirfd);
-    free(dirbuf);
-    free(basebuf);
-  }
-
-#define SUF "/criu"
-  const size_t criulen = jvm_path_len + fsl + sizeof(SUF);
-  char *criu = NEW_C_HEAP_ARRAY(char, criulen, mtInternal);
-  if (criu != NULL) {
-    int r = jio_snprintf(criu, criulen, "%s%s" SUF,
-      jvm_path, fs);
-    assert(r < (int)criulen, "len miscalc");
-  }
-#undef SUF
-  if (0 == stat(criu, &dummy)) {
-    _criu = criu;
-  } else {
-    FREE_C_HEAP_ARRAY(char, criu);
-    // use system one
-    _criu = "criu";
-  }
-
-  return true;
-}
 
 static void logOption(const char* opt) {
   if (PrintVMOptions) {
@@ -3145,22 +3063,6 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
     } else if (match_jfr_option(&option)) {
       return JNI_EINVAL;
 #endif
-    } else if (match_option(option, "-Zcheckpoint", &tail)) {
-      _crmode = Checkpoint;
-      if (!compute_criu_args(tail)) {
-        return JNI_EINVAL;
-      }
-    } else if (match_option(option, "-Zrestore", &tail)) {
-      // 1.6 msec to main function
-      // 4 msec to JLI arg parse function
-      // 4.6 msec to here
-      _crmode = Restore;
-      if (!compute_criu_args(tail)) {
-        return JNI_EINVAL;
-      }
-      if (os::Linux::restore()) {
-        return JNI_ERR;
-      }
     } else if (match_option(option, "-XX:", &tail)) { // -XX:xxxx
       // Skip -XX:Flags= and -XX:VMOptionsFile= since those cases have
       // already been handled
@@ -3376,6 +3278,19 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 #ifndef CAN_SHOW_REGISTERS_ON_ASSERT
   UNSUPPORTED_OPTION(ShowRegistersOnAssert);
 #endif // CAN_SHOW_REGISTERS_ON_ASSERT
+
+  if (CRaCRestoreFrom) {
+    os::Linux::restore();
+    if (CRaCRequireRestore) {
+      // FIXME switch to unified hotspot logging
+      warning("cannot restore");
+      return JNI_ERR;
+    }
+  }
+
+  if (CRaCCheckpointTo && !os::Linux::prepare_checkpoint()) {
+    return JNI_ERR;
+  }
 
   return JNI_OK;
 }

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -487,18 +487,6 @@ class Arguments : AllStatic {
                                          char** base_archive_path,
                                          char** top_archive_path) NOT_CDS_RETURN;
 
-  enum CRMode {
-    CRNone,
-    Checkpoint,
-    Restore
-  };
-
-  static CRMode _crmode;
-  static const char* _crdir;
-  static const char* _criu;
-
-  static bool compute_criu_args(const char* optdir);
-
  public:
   // Parses the arguments, first phase
   static jint parse(const JavaVMInitArgs* args);
@@ -664,16 +652,6 @@ class Arguments : AllStatic {
 
   static void assert_is_dumping_archive() {
     assert(Arguments::is_dumping_archive(), "dump time only");
-  }
-
-  static bool can_checkpoint() {
-    return _crmode == Checkpoint || CRAllowToSkipCheckpoint;
-  }
-  static const char* crdir() {
-    return _crdir;
-  }
-  static const char* criu() {
-    return _criu;
   }
 };
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2512,6 +2512,13 @@ const size_t minimumSymbolTableSize = 1024;
   experimental(bool, UseFastUnorderedTimeStamps, false,                     \
           "Use platform unstable time where supported for timestamps only") \
                                                                             \
+  product(ccstr, CRaCCheckpointTo, NULL, "Path to create the image")        \
+                                                                            \
+  product(ccstr, CRaCRestoreFrom, NULL, "Path to image to restore from")    \
+                                                                            \
+  product(bool, CRaCRequireRestore, false, "Unable to restore is a fatal"   \
+          "error")                                                          \
+                                                                            \
   diagnostic(bool, CRAllowToSkipCheckpoint, false,                          \
           "Allow implementation to not call Checkpoint if helper not found")\
                                                                             \

--- a/src/hotspot/share/runtime/perfMemory.hpp
+++ b/src/hotspot/share/runtime/perfMemory.hpp
@@ -164,7 +164,7 @@ class PerfMemory : AllStatic {
     // the caller is expected to free the allocated memory.
     static char* get_perfdata_file_path();
 
-    static bool checkpoint();
+    static bool checkpoint(const char* checkpoint_path);
     static bool checkpoint_fail();
     static bool restore();
 };

--- a/src/hotspot/share/runtime/perfMemory.hpp
+++ b/src/hotspot/share/runtime/perfMemory.hpp
@@ -163,10 +163,6 @@ class PerfMemory : AllStatic {
     // returns the complete file path of hsperfdata.
     // the caller is expected to free the allocated memory.
     static char* get_perfdata_file_path();
-
-    static bool checkpoint(const char* checkpoint_path);
-    static bool checkpoint_fail();
-    static bool restore();
 };
 
 void perfMemory_init();

--- a/src/java.base/unix/native/action-script/action-script.c
+++ b/src/java.base/unix/native/action-script/action-script.c
@@ -24,28 +24,65 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <limits.h>
 #include <stdlib.h>
+#include <errno.h>
 #include <unistd.h>
 #include <signal.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 #define RESTORE_SIGNAL   (SIGRTMIN + 2)
 
-#define MSGPREFIX "restore-script: "
+#define MSGPREFIX "action-script: "
 
 static int post_resume(void) {
 	char *pidstr = getenv("CRTOOLS_INIT_PID");
 	if (!pidstr) {
-		fprintf(stderr, MSGPREFIX "can not find CRTOOLS_INIT_PID env\n");
+		fprintf(stderr, MSGPREFIX "cannot find CRTOOLS_INIT_PID env\n");
 		return 1;
 	}
 	int pid = atoi(pidstr);
 
-    union sigval sv = { .sival_int = 0 };
+	union sigval sv = { .sival_int = 0 };
 	if (-1 == sigqueue(pid, RESTORE_SIGNAL, sv)) {
 		perror(MSGPREFIX "sigqueue");
 		return 1;
 	}
 
+	return 0;
+}
+
+static int post_dump(void) {
+	char realdir[PATH_MAX];
+
+	char *imgdir = getenv("CRTOOLS_IMAGE_DIR");
+	if (!imgdir) {
+		fprintf(stderr, MSGPREFIX "cannot find CRTOOLS_IMAGE_DIR env\n");
+		return 1;
+	}
+
+	if (!realpath(imgdir, realdir)) {
+		fprintf(stderr, MSGPREFIX "cannot canonicalize %s: %s\n", imgdir, strerror(errno));
+		return 1;
+	}
+
+	int dirfd = open(realdir, O_DIRECTORY);
+	if (dirfd < 0) {
+		fprintf(stderr, MSGPREFIX "can not open image dir %s: %s\n", realdir, strerror(errno));
+		return 1;
+	}
+
+	int fd = openat(dirfd, "cppath", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+	if (fd < 0) {
+		fprintf(stderr, MSGPREFIX "can not open file %s/cppath: %s\n", realdir, strerror(errno));
+		return 1;
+	}
+
+	if (write(fd, realdir, strlen(realdir)) < 0) {
+		fprintf(stderr, MSGPREFIX "can not write %s/cppath: %s\n", realdir, strerror(errno));
+		return 1;
+	}
 	return 0;
 }
 
@@ -64,6 +101,10 @@ int main(int argc, char *argv[]) {
 
 	if (!strcmp(action, "post-resume")) {
 		return post_resume();
+	}
+
+	if (!strcmp(action, "post-dump")) {
+		return post_dump();
 	}
 
 	return 0;

--- a/src/java.base/unix/native/restore-script/restore-script.c
+++ b/src/java.base/unix/native/restore-script/restore-script.c
@@ -30,8 +30,6 @@
 
 #define RESTORE_SIGNAL   (SIGRTMIN + 2)
 
-#define LOG "/tmp/restore4.log"
-
 #define MSGPREFIX "restore-script: "
 
 static int post_resume(void) {
@@ -51,13 +49,6 @@ static int post_resume(void) {
 	return 0;
 }
 
-static int restore_failed(void) {
-	dup2(2, 1);
-	printf("Troubles with restore: " LOG ":\n");
-	system("tail " LOG);
-	return 0;
-}
-
 /** Kicks VM after restore.
  * Started by CRIU on certain phases of restore process. Does nothing after all
  * phases except "post-resume" which is issued after complete restore. Then
@@ -73,10 +64,6 @@ int main(int argc, char *argv[]) {
 
 	if (!strcmp(action, "post-resume")) {
 		return post_resume();
-	}
-
-	if (!strcmp(action, "restore-failed")) {
-		return restore_failed();
 	}
 
 	return 0;

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/builder/DefaultImageBuilder.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/builder/DefaultImageBuilder.java
@@ -203,7 +203,7 @@ public final class DefaultImageBuilder implements ImageBuilder {
                         String fileName = path.getFileName().toString();
                         return fileName.equals("jspawnhelper")
                             || fileName.equals("jexec")
-                            || fileName.equals("restore-script")
+                            || fileName.equals("action-script")
                             || fileName.equals("wait")
                             || fileName.equals("criu")
                             || fileName.equals("javatime");


### PR DESCRIPTION
Add new options CRaCCheckpointTo and CRaCRestoreFrom for more flexible image management.

Image can be moved after checkpoint and restore from the image will succeed. But checkpoint of a restored process is not supported for now and will fail